### PR TITLE
Format time ranges with spaced dash

### DIFF
--- a/.github/workflows/erstelle_kalender.py
+++ b/.github/workflows/erstelle_kalender.py
@@ -88,10 +88,10 @@ def add_event_local(
                 is_all = True
             else:
                 if same_day:
-                    time_str = f"{start_local:%H:%M}–{end_local:%H:%M}"
+                    time_str = f"{start_local:%H:%M} – {end_local:%H:%M}"
                 elif ends_midnight_next and current == start_local.date():
-                    # 24h-Block: 00:00–00:00 → Ganztägig
-                    time_str = "Ganztägig" if start_local.time() == time.min else f"{start_local:%H:%M}–00:00"
+                    # 24h-Block: 00:00 – 00:00 → Ganztägig
+                    time_str = "Ganztägig" if start_local.time() == time.min else f"{start_local:%H:%M} – 00:00"
                 elif current == start_local.date():
                     time_str = f"Start: {start_local:%H:%M}"
                 elif current == loop_end_date and end_local.time() > time.min:


### PR DESCRIPTION
## Summary
- update local time range formatting in the calendar generator to insert spaces around the en dash
- keep midnight-spanning events consistent with the new spacing and adjust the related comment

## Testing
- ICS_URL=http://127.0.0.1:8000/test.ics python3 .github/workflows/erstelle_kalender.py

------
https://chatgpt.com/codex/tasks/task_e_68caa16b3cc4832b8f37d8582f9b0719