### PR TITLE
Adjust calendar header spacing

### DIFF
--- a/.github/workflows/erstelle_kalender.py
+++ b/.github/workflows/erstelle_kalender.py
@@ -172,7 +172,7 @@ header.topbar {{
 .topbar-inner {{
   display: flex;
   align-items: center;
-  gap: 48px;
+  gap: 72px;
   max-width: 1480px;
   margin: 0 auto;
   flex-wrap: wrap;
@@ -193,6 +193,7 @@ header.topbar {{
   flex-direction: column;
   gap: 18px;
   min-width: min(560px, 100%);
+  padding-left: 16px;
 }}
 .headline-text {{
   display: flex;


### PR DESCRIPTION
## Summary
- increase the header flex gap and add headline padding so the logo and text block sit further apart
- regenerated the static calendar to verify the new spacing in a 1920×1080 preview

## Testing
- ICS_URL=http://127.0.0.1:8000/sample.ics python3 .github/workflows/erstelle_kalender.py

------
https://chatgpt.com/codex/tasks/task_e_68cadb96ab80832ba8bd27943bdc5f14